### PR TITLE
React Beautiful DND v. 12.0.0 support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,8 +66,8 @@ const executeAsyncFnsSerially = fns =>
 /*
   react-beautiful-dnd utils
 */
-const DND_DROPPABLE_DATA_ATTR = '[data-react-beautiful-dnd-droppable]';
-export const DND_DRAGGABLE_DATA_ATTR = '[data-react-beautiful-dnd-draggable]';
+const DND_DROPPABLE_DATA_ATTR = '[data-rbd-droppable-context-id]';
+export const DND_DRAGGABLE_DATA_ATTR = '[data-rbd-draggable-context-id]';
 
 export const mockDndElSpacing = rtlUtils => {
   const droppables = rtlUtils.container.querySelectorAll(


### PR DESCRIPTION
Add support for React Beautiful DND v. 12.0.0  https://github.com/atlassian/react-beautiful-dnd/releases/tag/v12.0.0

```
For most people: you can safely upgrade to 12.0! 🎉 If you are doing any of the following then you will need to change some things. This is just a super quick reference to see if you can upgrade safely.

We have renamed our data-* attributes. So if you were using them (perhaps in a test), then things will break for you
```

This appears to fix it in my tests, but it would be good to add some tests around this...